### PR TITLE
Fix speakers and sponsors layout on mobile

### DIFF
--- a/components/landing/partners/partners.js
+++ b/components/landing/partners/partners.js
@@ -4,7 +4,7 @@ import { SPONSOR_APPLICATION_FORM_URL, YEAR } from "../../../constants";
 
 const partners = [
   { href: "https://polarisfinance.io/", img: "/images/partners/polaris.svg", alt: "Polaris logo" },
-  { href: "https://pharos.watch/", img: "/images/partners/pharos.svg", alt: "Pharos logo" },
+  { href: "https://pharos.watch/", img: "/images/partners/pharos.svg", alt: "Pharos logo", square: true },
   { href: "https://tenderly.co/", img: "/images/partners/tenderly.svg", alt: "Tenderly logo" },
   { href: "https://defisaver.com/", img: "/images/partners/defi-saver.png", alt: "DeFi Saver logo" },
   { href: "https://geodework.com/", img: "/images/partners/geodework.svg", alt: "Geodework logo" },
@@ -78,7 +78,7 @@ const Partners = () => (
         {partners.map((partner) => (
           <a
             key={partner.href}
-            className={styles.gridCell}
+            className={partner.square ? `${styles.gridCell} ${styles.squareLogo}` : styles.gridCell}
             href={partner.href}
             target="_blank"
             rel="noreferrer noopener"

--- a/components/landing/partners/partners.module.scss
+++ b/components/landing/partners/partners.module.scss
@@ -111,6 +111,12 @@
   }
 }
 
+// Square emblems (no wordmark) need more height to match the
+// visual weight of the wide logos capped at 32px
+.squareLogo img {
+  max-height: 56px;
+}
+
 .ctaSection {
   max-width: 860px;
   margin: 150px auto 120px;

--- a/components/landing/partners/partners.module.scss
+++ b/components/landing/partners/partners.module.scss
@@ -79,20 +79,26 @@
 
 .grid {
   display: grid;
-  grid-template-columns: repeat(5, 1fr);
+  // minmax(0, 1fr) lets cells shrink below their content's min size,
+  // otherwise the fixed-width logos blow the grid out of the viewport
+  grid-template-columns: repeat(5, minmax(0, 1fr));
   border-top: 1px solid var(--primary-red);
   border-left: 1px solid var(--primary-red);
 
   @include breakpoint(medium-screen) {
-    grid-template-columns: repeat(4, 1fr);
+    grid-template-columns: repeat(4, minmax(0, 1fr));
   }
 
   @include breakpoint(tablet) {
-    grid-template-columns: repeat(3, 1fr);
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+
+  @include breakpoint(landscape) {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 
   @include breakpoint(big-mobile) {
-    grid-template-columns: repeat(2, 1fr);
+    grid-template-columns: minmax(0, 1fr);
   }
 }
 
@@ -105,16 +111,17 @@
   border-bottom: 1px solid var(--primary-red);
 
   img {
-    max-width: 120px;
+    max-width: min(120px, 100%);
     max-height: 32px;
     object-fit: contain;
   }
 }
 
-// Square emblems (no wordmark) need more height to match the
-// visual weight of the wide logos capped at 32px
+// Square emblems (no wordmark) need more height than the 32px cap on
+// wide logos, but not so much that they outweigh the wordmarks
 .squareLogo img {
-  max-height: 56px;
+  max-width: 42px;
+  max-height: 42px;
 }
 
 .ctaSection {

--- a/components/landing/speakers/speakers.module.scss
+++ b/components/landing/speakers/speakers.module.scss
@@ -89,6 +89,10 @@
   border-right: 1px solid var(--primary-red);
   border-bottom: 1px solid var(--primary-red);
 
+  @include breakpoint(big-mobile) {
+    padding: 20px 12px;
+  }
+
   img {
     width: 100px;
     height: 100px;
@@ -125,9 +129,14 @@
     mask-image: linear-gradient(to bottom, black 82%, transparent 100%);
     -webkit-mask-image: linear-gradient(to bottom, black 82%, transparent 100%);
 
+    // Phones: photos vary a lot in natural size, so fill the cutout box
+    // uniformly instead of rendering each at its own scale
     @include breakpoint(big-mobile) {
-      width: auto;
-      height: auto;
+      width: 100%;
+      height: 100%;
+      max-width: 100%;
+      object-fit: contain;
+      object-position: bottom center;
     }
   }
 

--- a/components/landing/speakers/speakers.module.scss
+++ b/components/landing/speakers/speakers.module.scss
@@ -62,21 +62,27 @@
 
 .grid {
   display: grid;
-  grid-template-columns: repeat(5, 1fr);
+  // minmax(0, 1fr) lets cells shrink below their content's min size,
+  // otherwise long single-word names blow the grid out of the viewport
+  grid-template-columns: repeat(5, minmax(0, 1fr));
   border-top: 1px solid var(--primary-red);
   border-left: 1px solid var(--primary-red);
   margin-bottom: 72px;
 
   @include breakpoint(medium-screen) {
-    grid-template-columns: repeat(4, 1fr);
+    grid-template-columns: repeat(4, minmax(0, 1fr));
   }
 
   @include breakpoint(tablet) {
-    grid-template-columns: repeat(3, 1fr);
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+
+  @include breakpoint(landscape) {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 
   @include breakpoint(big-mobile) {
-    grid-template-columns: repeat(2, 1fr);
+    grid-template-columns: minmax(0, 1fr);
   }
 }
 


### PR DESCRIPTION
Fixes both sections looking broken on small screens:

- Grid columns used `1fr` (a `minmax(auto, 1fr)` floor), so cells could not shrink below their content width and both grids overflowed the viewport on narrow screens. Now `minmax(0, 1fr)` at every breakpoint.
- Speakers and sponsors show one item per row under 480px, two columns between 480–640px.
- Speaker photos fill the cutout uniformly on phones (object-fit: contain, bottom-anchored) instead of rendering at wildly different natural sizes.
- Square Pharos emblem capped at 42×42px so it matches the visual weight of the wordmark logos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)