### PR TITLE
Add /verify channel verification page

### DIFF
--- a/components/common/navigation/navigation.js
+++ b/components/common/navigation/navigation.js
@@ -75,6 +75,9 @@ const MainMenu = ({ setOpenMobileMenu = () => { } }) => (
         <Link href="https://joobpool.com/" target="_blank" rel="noreferrer noopener">
           <span className={styles.menuItem}>Jobs</span>
         </Link>
+        <Link href="/verify">
+          <span className={styles.menuItem}>Verify</span>
+        </Link>
         <div className={styles.showOnHamburger}>
           <Link href={BGBW_URL} target="_blank" rel="noreferrer noopener">
             <span className={styles.menuItem}>Side Events</span>

--- a/components/verify/verified-channels.json
+++ b/components/verify/verified-channels.json
@@ -1,0 +1,195 @@
+{
+  "emailDomains": [
+    "ethbelgrade.rs"
+  ],
+  "kdf": {
+    "salt": "a392976796a95994a4bba7f6bf4295dc",
+    "iterations": 600000
+  },
+  "channels": [
+    {
+      "type": "x",
+      "handle": "@ethbelgrade",
+      "name": "ETH Belgrade",
+      "role": "Official account",
+      "url": "https://x.com/ethbelgrade"
+    },
+    {
+      "type": "telegram",
+      "handle": "https://t.me/+JHSH1qc-W85kYzdk",
+      "name": "ETH Belgrade Community",
+      "role": "Official group (invite link)",
+      "url": "https://t.me/+JHSH1qc-W85kYzdk"
+    },
+    {
+      "type": "linkedin",
+      "handle": "linkedin.com/company/eth-belgrade",
+      "name": "ETH Belgrade",
+      "role": "Official company page",
+      "url": "https://www.linkedin.com/company/eth-belgrade/"
+    },
+    {
+      "type": "telegram",
+      "hashes": [
+        "4c3766048ffcef692c467bbc1949da773a40cb5fa5252614a65d5e54dcee72db"
+      ],
+      "name": "Petar Popovic",
+      "role": "ETH Belgrade team"
+    },
+    {
+      "type": "x",
+      "hashes": [
+        "4c1ad6b1d5dd8c68f618b154c87a39430edfbeae4bd8c8a9caf890a8576003ee"
+      ],
+      "name": "Petar Popovic",
+      "role": "ETH Belgrade team"
+    },
+    {
+      "type": "telegram",
+      "hashes": [
+        "5af75ce64625b287c462b674fd1f2e171279c9db5dee28b2e15726b0369c0273"
+      ],
+      "name": "Tanja Mladenovic",
+      "role": "ETH Belgrade team"
+    },
+    {
+      "type": "x",
+      "hashes": [
+        "ed943cf90eb45958eb41bd4d9889ba6d1114a816ef136b23e25bcfbb4204627d"
+      ],
+      "name": "Tanja Mladenovic",
+      "role": "ETH Belgrade team"
+    },
+    {
+      "type": "phone",
+      "hashes": [
+        "e84ad35ada5aebae17596e12488b83c7c4d299910d5c58bffb4d1d54c6585da0",
+        "1a47ba5302325171f7ea7f8975e73d16a942ad1e28e7d84a10d76b246da6e1af"
+      ],
+      "name": "Tanja Mladenovic",
+      "role": "ETH Belgrade team"
+    },
+    {
+      "type": "email",
+      "hashes": [
+        "fa69532d28ea7aaca2b44be34620112657a627bf353e46100d966085ae2a071f"
+      ],
+      "name": "Tanja Mladenovic",
+      "role": "ETH Belgrade team"
+    },
+    {
+      "type": "telegram",
+      "hashes": [
+        "f9064695618c71e5d2cad7c9b1735bed26229a64400b206a6948dff2fc47a1a0"
+      ],
+      "name": "Lejla Muratcaus",
+      "role": "ETH Belgrade team"
+    },
+    {
+      "type": "telegram",
+      "hashes": [
+        "a5152a43d5a227fb58abead065430e13491fbad12bf8de377d29f8e2eb599401"
+      ],
+      "name": "Miros",
+      "role": "ETH Belgrade team"
+    },
+    {
+      "type": "x",
+      "hashes": [
+        "76f92283d3eb5e47a02437299b6e1fb894b401762470a55430bae30abd942a2a"
+      ],
+      "name": "Miros",
+      "role": "ETH Belgrade team"
+    },
+    {
+      "type": "telegram",
+      "hashes": [
+        "f083a0559a24ba60787521be90c276fc318b74adcdd9063446315b5ee8939a10"
+      ],
+      "name": "Ana",
+      "role": "ETH Belgrade team"
+    },
+    {
+      "type": "x",
+      "hashes": [
+        "474c83253aefbbbf6d27b2cf5c3b8cbdd805ffa5906247d5ebbb379aa37530f4"
+      ],
+      "name": "Ana",
+      "role": "ETH Belgrade team"
+    },
+    {
+      "type": "telegram",
+      "hashes": [
+        "f074863963009f31f37d8944dde53231adab092939053d086600abe969bc91b1"
+      ],
+      "name": "Lav Leon Hudak",
+      "role": "ETH Belgrade team"
+    },
+    {
+      "type": "x",
+      "hashes": [
+        "d93a131d319fe537a9183ac4cfe0c3550ac26e0c655bf62dc5d685aa53fde839"
+      ],
+      "name": "Lav Leon Hudak",
+      "role": "ETH Belgrade team"
+    },
+    {
+      "type": "phone",
+      "hashes": [
+        "4fb92204b5c2e7564120f93b69be7ebb6ac5ab10bac64017956c19d90ffa5735",
+        "145299f8751dd2da5f508ca007138d068c77220bdb0c88bd33feffa22a763590"
+      ],
+      "name": "Lav Leon Hudak",
+      "role": "ETH Belgrade team"
+    },
+    {
+      "type": "telegram",
+      "hashes": [
+        "24d3f2c133aa6a90f3f7b9d1b350f91be9cf34b7f7a2b9f4cd4ebbe55b8d1f8d"
+      ],
+      "name": "Filip Pajic",
+      "role": "ETH Belgrade team"
+    },
+    {
+      "type": "x",
+      "hashes": [
+        "e9bb5722fbe23f3975429f7ed3b1e750c3eb33d2961960fda78572642771658f"
+      ],
+      "name": "Filip Pajic",
+      "role": "ETH Belgrade team"
+    },
+    {
+      "type": "phone",
+      "hashes": [
+        "317ba3ad685f77a19c4cf9528641908ce51d2d49177efcbc676840f6f490e996",
+        "084fece2a85404d10e2c90e33924b30a33aff0b2a88e46e2c381634b623585b8"
+      ],
+      "name": "Filip Pajic",
+      "role": "ETH Belgrade team"
+    },
+    {
+      "type": "email",
+      "hashes": [
+        "1aa106242d60a4b0eb3d35c53ca6d7eb2e74d7695214340d54e6c59733567998"
+      ],
+      "name": "Speakers",
+      "role": "Official speakers inbox"
+    },
+    {
+      "type": "email",
+      "hashes": [
+        "dedc16306f1b20fad3925444e0b53057f8f1e66c7daad33dee19c15fc38c31e3"
+      ],
+      "name": "Partnerships",
+      "role": "Official partnerships inbox"
+    },
+    {
+      "type": "email",
+      "hashes": [
+        "2c1a2bed09447bcc2a1f8c651c8bb0c69b222ec5ef49dd9a6aa552c0901898c6"
+      ],
+      "name": "General inquiries",
+      "role": "Official general inbox"
+    }
+  ]
+}

--- a/components/verify/verify.js
+++ b/components/verify/verify.js
@@ -1,0 +1,246 @@
+import { useState } from "react";
+
+import styles from "./verify.module.scss";
+import Button from "../common/button/button";
+import { PLATFORM_LABELS } from "./verifyLogic";
+
+const Verify = ({ publicChannels }) => {
+  const [platform, setPlatform] = useState("telegram");
+  const [input, setInput] = useState("");
+  const [result, setResult] = useState(null);
+  const [checking, setChecking] = useState(false);
+
+  const handleSubmit = async (event) => {
+    event.preventDefault();
+    if (!input.trim() || checking) return;
+    setChecking(true);
+    try {
+      const response = await fetch("/api/verify", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ input, platform }),
+      });
+      if (response.status === 429) {
+        setResult({ status: "rateLimited" });
+      } else if (!response.ok) {
+        setResult({ status: "error" });
+      } else {
+        setResult(await response.json());
+      }
+    } catch {
+      setResult({ status: "error" });
+    } finally {
+      setChecking(false);
+    }
+  };
+
+  const handleInputChange = (event) => {
+    setInput(event.target.value);
+    setResult(null);
+  };
+
+  return (
+    <div className={styles.verify}>
+      <div className="container">
+        <div className={styles.header}>
+          <h1 className={styles.title}>Channel Verification</h1>
+          <p className={styles.subtitle}>
+            Scammers impersonate the ETH Belgrade team over Telegram, X, email, and phone.
+            Use this page to check whether an account, address, or number officially belongs to us.
+          </p>
+        </div>
+
+        <div className={styles.grid}>
+          <div>
+            <form className={styles.checkerCard} onSubmit={handleSubmit}>
+              <label className={styles.label} htmlFor="verify-platform">Channel</label>
+              <select
+                id="verify-platform"
+                className={styles.select}
+                value={platform}
+                onChange={(event) => { setPlatform(event.target.value); setResult(null); }}
+              >
+                {Object.entries(PLATFORM_LABELS).map(([value, label]) => (
+                  <option key={value} value={value}>{label}</option>
+                ))}
+              </select>
+
+              <label className={styles.label} htmlFor="verify-input">Channel details</label>
+              <input
+                id="verify-input"
+                className={styles.input}
+                type="text"
+                value={input}
+                onChange={handleInputChange}
+                placeholder="Enter username, email, phone number, or profile link"
+                autoComplete="off"
+                autoCapitalize="off"
+                spellCheck="false"
+              />
+              <p className={styles.hint}>
+                Copy the exact username from the profile you want to check. Be careful with
+                similar-looking characters such as I (i), l (L), O, and 0 — your input must match
+                the characters shown in the channel exactly.
+              </p>
+
+              <Button styleType="red" type="submit" disabled={checking}>
+                {checking ? "Verifying…" : "Verify"}
+              </Button>
+            </form>
+
+            {result && result.status === "verified" && (
+              <div className={`${styles.result} ${styles.resultVerified}`}>
+                <p className={styles.resultTitle}>✓ Verified official channel</p>
+                <p className={styles.resultHandle}>{result.match.handle || result.input}</p>
+                <p className={styles.resultMeta}>
+                  {PLATFORM_LABELS[result.match.type] || result.match.type} — {result.match.name}
+                  {result.match.role ? ` · ${result.match.role}` : ""}
+                </p>
+                <p className={styles.resultText}>
+                  Compare it character by character with the channel you are checking. If it differs
+                  in any way — an extra underscore, a capital I instead of a lowercase l — it is not us.
+                </p>
+              </div>
+            )}
+
+            {result && result.status === "officialDomain" && (
+              <div className={`${styles.result} ${styles.resultWarning}`}>
+                <p className={styles.resultTitle}>Official domain, unlisted address</p>
+                <p className={styles.resultHandle}>{result.input}</p>
+                <p className={styles.resultText}>
+                  This address is on our official @{result.domain} domain, but it is not on our
+                  published list. Email addresses can be spoofed — before acting on anything sensitive,
+                  confirm through one of the verified channels below.
+                </p>
+              </div>
+            )}
+
+            {result && result.status === "notVerified" && (
+              <div className={`${styles.result} ${styles.resultDanger}`}>
+                <p className={styles.resultTitle}>✗ Not an official ETH Belgrade channel</p>
+                <p className={styles.resultHandle}>{result.input}</p>
+                <p className={styles.resultText}>
+                  We could not verify this as an official ETH Belgrade channel. Do not engage,
+                  do not send funds, and do not share personal information. If someone is impersonating
+                  our team, please report it to us through a verified channel below.
+                </p>
+              </div>
+            )}
+
+            {result && result.status === "rateLimited" && (
+              <div className={`${styles.result} ${styles.resultWarning}`}>
+                <p className={styles.resultTitle}>Too many attempts</p>
+                <p className={styles.resultText}>
+                  Please wait a minute and try again.
+                </p>
+              </div>
+            )}
+
+            {result && result.status === "error" && (
+              <div className={`${styles.result} ${styles.resultWarning}`}>
+                <p className={styles.resultTitle}>Something went wrong</p>
+                <p className={styles.resultText}>
+                  We couldn&apos;t run the check. Please try again.
+                </p>
+              </div>
+            )}
+
+            {result && result.status === "suspicious" && (
+              <div className={`${styles.result} ${styles.resultDanger}`}>
+                <p className={styles.resultTitle}>⚠ Contains unusual characters</p>
+                <p className={styles.resultHandle}>{result.input}</p>
+                <p className={styles.resultText}>
+                  Your input contains non-standard characters that imitate normal letters — a common
+                  scam technique (for example, a Cyrillic &quot;а&quot; instead of a Latin &quot;a&quot;).
+                  This is not an official ETH Belgrade channel. Do not engage.
+                </p>
+              </div>
+            )}
+          </div>
+
+          <aside className={styles.notice}>
+            <p className={styles.noticeTitle}>Important notice</p>
+            <p>
+              All official emails from ETH Belgrade are sent from addresses ending in
+              <strong> @ethbelgrade.rs</strong> — check the spelling of the domain carefully.
+            </p>
+            <p>
+              Our team will <strong>never</strong> DM you first to ask for payment, wallet access,
+              seed phrases, private keys, or a &quot;deposit&quot; to confirm a ticket, sponsorship,
+              or speaking slot.
+            </p>
+            <p>
+              Do not engage with unverified sources, and do not share personal or project
+              information with them.
+            </p>
+          </aside>
+        </div>
+
+        <div className={styles.section}>
+          <h2 className={styles.sectionTitle}>Make sure you&apos;re checking the right field</h2>
+          <div className={styles.compareGrid}>
+            <div className={`${styles.compareCard} ${styles.compareGood}`}>
+              <p className={styles.compareBadge}>✓ Username</p>
+              <p className={styles.compareExample}>@ethbelgrade</p>
+              <p className={styles.compareText}>
+                The username is unique — no two accounts can share it. This is the only field
+                worth verifying.
+              </p>
+            </div>
+            <div className={`${styles.compareCard} ${styles.compareBad}`}>
+              <p className={styles.compareBadge}>✗ Display name / bio</p>
+              <p className={styles.compareExample}>ETH Belgrade Team</p>
+              <p className={styles.compareText}>
+                Anyone can put anything in their display name, bio, or profile photo.
+                Never trust these fields.
+              </p>
+            </div>
+          </div>
+          <p className={styles.sectionText}>
+            Scammers often hide or remove their username and imitate official ETH Belgrade names in
+            their bio and display name. Open the user&apos;s profile page and verify the actual
+            <strong> username</strong> field — not the name shown in the chat.
+          </p>
+        </div>
+
+        <div className={styles.section}>
+          <h2 className={styles.sectionTitle}>Official channels</h2>
+          <div className={styles.channelsList}>
+            {publicChannels.map((channel) => (
+              <div key={`${channel.type}-${channel.handle}`} className={styles.channelCard}>
+                <p className={styles.channelPlatform}>{PLATFORM_LABELS[channel.type] || channel.type}</p>
+                {channel.url ? (
+                  <a className={styles.channelHandle} href={channel.url} target="_blank" rel="noreferrer noopener">
+                    {channel.handle}
+                  </a>
+                ) : (
+                  <p className={styles.channelHandle}>{channel.handle}</p>
+                )}
+                <p className={styles.channelMeta}>
+                  {channel.name}
+                  {channel.role ? ` · ${channel.role}` : ""}
+                </p>
+              </div>
+            ))}
+          </div>
+          <p className={styles.sectionText}>
+            Individual team members&apos; contacts are not listed publicly — use the checker above
+            to verify a specific handle, email address, or phone number someone gives you.
+          </p>
+        </div>
+
+        <div className={styles.disclaimer}>
+          <p className={styles.disclaimerTitle}>Disclaimer</p>
+          <p>
+            We strive to keep the information on this page accurate and up to date; however, it may
+            not always be complete or current. All information is provided on an &quot;as is&quot;
+            basis, without warranties of any kind. Any information provided by our team is for
+            information purposes only and is not financial, investment, or legal advice.
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default Verify;

--- a/components/verify/verify.module.scss
+++ b/components/verify/verify.module.scss
@@ -1,0 +1,407 @@
+@import "styles/breakpoints";
+
+.verify {
+  padding: 150px 0 100px;
+
+  @include breakpoint(landscape) {
+    padding: 100px 0 60px;
+  }
+}
+
+.header {
+  max-width: 800px;
+  margin-bottom: 50px;
+
+  @include breakpoint(landscape) {
+    margin-bottom: 30px;
+  }
+}
+
+.title {
+  font-family: var(--anton);
+  font-size: 64px;
+  font-weight: 400;
+  line-height: 1.1;
+  text-transform: uppercase;
+  color: #fff;
+  margin: 0 0 16px;
+
+  @include breakpoint(big-tablet) {
+    font-size: 48px;
+  }
+
+  @include breakpoint(big-mobile) {
+    font-size: 36px;
+  }
+}
+
+.subtitle {
+  font-size: 20px;
+  color: var(--primary-gray);
+  margin: 0;
+
+  @include breakpoint(big-mobile) {
+    font-size: 16px;
+  }
+}
+
+.grid {
+  display: grid;
+  grid-template-columns: 1fr 380px;
+  gap: 40px;
+  align-items: start;
+  margin-bottom: 80px;
+
+  @include breakpoint(big-tablet) {
+    grid-template-columns: 1fr;
+    gap: 30px;
+    margin-bottom: 60px;
+  }
+}
+
+.checkerCard {
+  border: 1px solid rgba(251, 246, 238, 0.15);
+  background: rgba(251, 246, 238, 0.03);
+  padding: 30px;
+
+  @include breakpoint(big-mobile) {
+    padding: 20px;
+  }
+}
+
+.label {
+  display: block;
+  font-family: var(--roboto-mono);
+  font-size: 14px;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+  color: var(--primary-gray);
+  margin-bottom: 8px;
+}
+
+.select,
+.input {
+  width: 100%;
+  padding: 14px 16px;
+  margin-bottom: 24px;
+  font-family: var(--space-grotesk);
+  font-size: 16px;
+  color: var(--primary-gray);
+  background: var(--primary-black);
+  border: 1px solid rgba(251, 246, 238, 0.3);
+  border-radius: 0;
+  appearance: none;
+  outline: none;
+
+  &:focus {
+    border-color: var(--primary-red);
+  }
+}
+
+.select {
+  cursor: pointer;
+  background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='12' height='8' viewBox='0 0 12 8'><path d='M1 1l5 5 5-5' stroke='%23FBF6EE' stroke-width='2' fill='none'/></svg>");
+  background-repeat: no-repeat;
+  background-position: right 16px center;
+}
+
+.input {
+  margin-bottom: 12px;
+
+  &::placeholder {
+    color: rgba(251, 246, 238, 0.4);
+  }
+}
+
+.hint {
+  font-size: 14px;
+  line-height: 1.5;
+  color: rgba(251, 246, 238, 0.6);
+  margin: 0 0 24px;
+}
+
+.result {
+  margin-top: 24px;
+  padding: 24px 30px;
+  border: 1px solid;
+
+  @include breakpoint(big-mobile) {
+    padding: 20px;
+  }
+}
+
+.resultVerified {
+  border-color: var(--primary-emerald);
+  background: rgba(76, 224, 179, 0.08);
+
+  .resultTitle {
+    color: var(--primary-emerald);
+  }
+}
+
+.resultWarning {
+  border-color: var(--primary-orange);
+  background: rgba(252, 158, 79, 0.08);
+
+  .resultTitle {
+    color: var(--primary-orange);
+  }
+}
+
+.resultDanger {
+  border-color: var(--primary-red);
+  background: rgba(239, 35, 60, 0.08);
+
+  .resultTitle {
+    color: var(--primary-red);
+  }
+}
+
+.resultTitle {
+  font-family: var(--anton);
+  font-size: 24px;
+  text-transform: uppercase;
+  margin: 0 0 12px;
+
+  @include breakpoint(big-mobile) {
+    font-size: 20px;
+  }
+}
+
+.resultHandle {
+  font-family: var(--roboto-mono);
+  font-size: 20px;
+  color: #fff;
+  word-break: break-all;
+  margin: 0 0 8px;
+
+  @include breakpoint(big-mobile) {
+    font-size: 16px;
+  }
+}
+
+.resultMeta {
+  font-family: var(--roboto-mono);
+  font-size: 14px;
+  color: var(--primary-gray);
+  margin: 0 0 16px;
+}
+
+.resultText {
+  font-size: 16px;
+  line-height: 1.5;
+  color: var(--primary-gray);
+  margin: 0;
+}
+
+.notice {
+  border: 1px solid rgba(251, 246, 238, 0.15);
+  background: rgba(251, 246, 238, 0.03);
+  padding: 30px;
+
+  p {
+    font-size: 16px;
+    line-height: 1.5;
+    color: var(--primary-gray);
+    margin: 0 0 16px;
+
+    &:last-child {
+      margin-bottom: 0;
+    }
+  }
+
+  strong {
+    color: #fff;
+  }
+
+  @include breakpoint(big-mobile) {
+    padding: 20px;
+  }
+}
+
+.noticeTitle {
+  font-family: var(--anton);
+  font-size: 24px;
+  text-transform: uppercase;
+  color: #fff !important;
+  margin: 0 0 16px !important;
+}
+
+.section {
+  margin-bottom: 80px;
+
+  @include breakpoint(landscape) {
+    margin-bottom: 60px;
+  }
+}
+
+.sectionTitle {
+  font-family: var(--anton);
+  font-size: 40px;
+  font-weight: 400;
+  line-height: 1.1;
+  text-transform: uppercase;
+  color: #fff;
+  margin: 0 0 30px;
+
+  @include breakpoint(big-tablet) {
+    font-size: 32px;
+  }
+
+  @include breakpoint(big-mobile) {
+    font-size: 26px;
+  }
+}
+
+.sectionText {
+  max-width: 800px;
+  font-size: 18px;
+  line-height: 1.5;
+  color: var(--primary-gray);
+  margin: 30px 0 0;
+
+  strong {
+    color: #fff;
+  }
+
+  @include breakpoint(big-mobile) {
+    font-size: 16px;
+  }
+}
+
+.compareGrid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 30px;
+  max-width: 800px;
+
+  @include breakpoint(landscape) {
+    grid-template-columns: 1fr;
+    gap: 20px;
+  }
+}
+
+.compareCard {
+  border: 1px solid;
+  padding: 30px;
+
+  @include breakpoint(big-mobile) {
+    padding: 20px;
+  }
+}
+
+.compareGood {
+  border-color: var(--primary-emerald);
+  background: rgba(76, 224, 179, 0.08);
+
+  .compareBadge {
+    color: var(--primary-emerald);
+  }
+}
+
+.compareBad {
+  border-color: var(--primary-red);
+  background: rgba(239, 35, 60, 0.08);
+
+  .compareBadge {
+    color: var(--primary-red);
+  }
+}
+
+.compareBadge {
+  font-family: var(--roboto-mono);
+  font-size: 14px;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+  margin: 0 0 12px;
+}
+
+.compareExample {
+  font-family: var(--roboto-mono);
+  font-size: 24px;
+  color: #fff;
+  margin: 0 0 12px;
+
+  @include breakpoint(big-mobile) {
+    font-size: 20px;
+  }
+}
+
+.compareText {
+  font-size: 16px;
+  line-height: 1.5;
+  color: var(--primary-gray);
+  margin: 0;
+}
+
+.channelsList {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 30px;
+
+  @include breakpoint(small-screen) {
+    grid-template-columns: repeat(2, 1fr);
+  }
+
+  @include breakpoint(landscape) {
+    grid-template-columns: 1fr;
+    gap: 20px;
+  }
+}
+
+.channelCard {
+  border: 1px solid rgba(251, 246, 238, 0.15);
+  background: rgba(251, 246, 238, 0.03);
+  padding: 24px;
+}
+
+.channelPlatform {
+  font-family: var(--roboto-mono);
+  font-size: 13px;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+  color: var(--primary-emerald);
+  margin: 0 0 10px;
+}
+
+.channelHandle {
+  display: block;
+  font-family: var(--roboto-mono);
+  font-size: 16px;
+  color: #fff;
+  word-break: break-all;
+  text-decoration: none;
+  margin: 0 0 8px;
+
+  &:hover {
+    color: var(--primary-emerald);
+  }
+}
+
+.channelMeta {
+  font-size: 14px;
+  color: rgba(251, 246, 238, 0.6);
+  margin: 0;
+}
+
+.disclaimer {
+  max-width: 800px;
+  border-top: 1px solid rgba(251, 246, 238, 0.15);
+  padding-top: 30px;
+
+  p {
+    font-size: 14px;
+    line-height: 1.5;
+    color: rgba(251, 246, 238, 0.6);
+    margin: 0;
+  }
+}
+
+.disclaimerTitle {
+  font-family: var(--roboto-mono);
+  font-size: 14px;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+  color: var(--primary-gray) !important;
+  margin: 0 0 12px !important;
+}

--- a/components/verify/verifyLogic.js
+++ b/components/verify/verifyLogic.js
@@ -1,0 +1,176 @@
+export const PLATFORM_LABELS = {
+  telegram: "Telegram",
+  x: "X (Twitter)",
+  email: "Email",
+  phone: "Phone number",
+  linkedin: "LinkedIn",
+};
+
+const PLATFORM_DOMAINS = {
+  telegram: ["t.me", "telegram.me", "telegram.dog"],
+  x: ["x.com", "twitter.com"],
+  linkedin: ["linkedin.com"],
+};
+
+// Homoglyph check runs on the raw input, BEFORE any unicode normalization —
+// normalizing first would fold lookalike characters into their ASCII twins
+// and let a fake handle verify as real.
+const hasNonAsciiCharacters = (raw) => /[^\x00-\x7F]/.test(raw);
+
+export const cleanValue = (raw) => {
+  let value = raw.trim().toLowerCase();
+  value = value.split("?")[0].split("#")[0];
+  value = value
+    .replace(/^mailto:/, "")
+    .replace(/^https?:\/\//, "")
+    .replace(/^www\./, "")
+    .replace(/\/+$/, "");
+  return value;
+};
+
+const detectPlatform = (cleaned) => {
+  if (/^[^@\s/]+@[^@\s/]+\.[^@\s/]+$/.test(cleaned)) return "email";
+
+  for (const [platform, domains] of Object.entries(PLATFORM_DOMAINS)) {
+    if (domains.some((domain) => cleaned === domain || cleaned.startsWith(`${domain}/`))) {
+      return platform;
+    }
+  }
+
+  return null;
+};
+
+export const extractHandle = (cleaned) => {
+  let handle = cleaned;
+
+  for (const domain of Object.values(PLATFORM_DOMAINS).flat()) {
+    if (handle.startsWith(`${domain}/`)) {
+      handle = handle.slice(domain.length + 1);
+      break;
+    }
+  }
+
+  return handle
+    .replace(/^(company|in)\//, "")
+    .replace(/^@/, "")
+    .replace(/\/+$/, "");
+};
+
+const isPhoneLike = (cleaned) => /^[+0-9][0-9\s()./-]{5,}$/.test(cleaned);
+
+// "00" is the international dialing prefix — 00381… and +381… are the same number
+export const normalizePhoneDigits = (value) => value.replace(/\D/g, "").replace(/^00/, "");
+
+// Compare phone numbers on digits only, accepting the local form of an
+// international number (064 123 4567 vs +381 64 123 4567) in either direction.
+const phonesMatch = (inputPhone, entryPhone) => {
+  const a = normalizePhoneDigits(inputPhone);
+  const b = normalizePhoneDigits(entryPhone);
+  if (!a || !b) return false;
+  if (a === b) return true;
+
+  const localTail = (value) => (value.startsWith("0") && value.length >= 7 ? value.slice(1) : null);
+  const tailA = localTail(a);
+  const tailB = localTail(b);
+  if (tailA && b.endsWith(tailA)) return true;
+  if (tailB && a.endsWith(tailB)) return true;
+  return false;
+};
+
+const hexToBytes = (hex) => new Uint8Array(hex.match(/.{2}/g).map((byte) => parseInt(byte, 16)));
+
+const bytesToHex = (bytes) => Array.from(bytes, (b) => b.toString(16).padStart(2, "0")).join("");
+
+// Personal contacts are stored only as PBKDF2 hashes so neither the public
+// repo nor the bundle contains the actual values. The salt in the data file is
+// combined with a secret pepper (VERIFY_PEPPER env var, never in git) — without
+// the pepper the hashes cannot be brute-forced, which matters for phone numbers
+// where the keyspace is small. The hash input is "<type>:<normalized value>" so
+// the same handle on different platforms produces different hashes.
+export const deriveHash = async (type, value, kdf, pepper) => {
+  const encoder = new TextEncoder();
+  const key = await crypto.subtle.importKey("raw", encoder.encode(`${type}:${value}`), "PBKDF2", false, ["deriveBits"]);
+  const saltBytes = hexToBytes(kdf.salt);
+  const pepperBytes = encoder.encode(pepper);
+  const salt = new Uint8Array(saltBytes.length + pepperBytes.length);
+  salt.set(saltBytes);
+  salt.set(pepperBytes, saltBytes.length);
+  const bits = await crypto.subtle.deriveBits(
+    { name: "PBKDF2", hash: "SHA-256", salt, iterations: kdf.iterations },
+    key,
+    256
+  );
+  return bytesToHex(new Uint8Array(bits));
+};
+
+const findMatch = async (verifiedChannels, type, plaintextPredicate, hashValue, pepper) => {
+  const plainMatch = verifiedChannels.channels.find(
+    (channel) => channel.type === type && channel.handle && plaintextPredicate(channel)
+  );
+  if (plainMatch) return plainMatch;
+
+  if (verifiedChannels.kdf && hashValue && pepper) {
+    const hash = await deriveHash(type, hashValue, verifiedChannels.kdf, pepper);
+    return verifiedChannels.channels.find(
+      (channel) => channel.type === type && Array.isArray(channel.hashes) && channel.hashes.includes(hash)
+    );
+  }
+
+  return undefined;
+};
+
+export const checkInput = async (rawInput, selectedPlatform, verifiedChannels, pepper) => {
+  if (hasNonAsciiCharacters(rawInput)) {
+    return { status: "suspicious", input: rawInput.trim() };
+  }
+
+  const cleaned = cleanValue(rawInput);
+  const platform = detectPlatform(cleaned) || selectedPlatform;
+
+  if (platform === "email") {
+    const email = cleaned.replace(/^@/, "");
+    const match = await findMatch(
+      verifiedChannels,
+      "email",
+      (channel) => cleanValue(channel.handle) === email,
+      email,
+      pepper
+    );
+    if (match) return { status: "verified", input: email, match };
+
+    const domain = email.includes("@") ? email.split("@").pop() : null;
+    if (domain && verifiedChannels.emailDomains.includes(domain)) {
+      return { status: "officialDomain", input: email, domain };
+    }
+
+    return { status: "notVerified", input: email, platform };
+  }
+
+  if (platform === "phone" || isPhoneLike(cleaned)) {
+    const digits = normalizePhoneDigits(cleaned);
+    const match = await findMatch(
+      verifiedChannels,
+      "phone",
+      (channel) => phonesMatch(cleaned, channel.handle),
+      digits,
+      pepper
+    );
+    if (match) return { status: "verified", input: cleaned, match };
+    return { status: "notVerified", input: cleaned, platform: "phone" };
+  }
+
+  const handle = extractHandle(cleaned);
+  if (!handle) return { status: "notVerified", input: cleaned, platform };
+
+  const match = await findMatch(
+    verifiedChannels,
+    platform,
+    (channel) => extractHandle(cleanValue(channel.handle)) === handle,
+    handle,
+    pepper
+  );
+
+  if (match) return { status: "verified", input: handle, match };
+
+  return { status: "notVerified", input: cleaned, platform };
+};

--- a/pages/api/verify.js
+++ b/pages/api/verify.js
@@ -1,0 +1,61 @@
+import verifiedChannels from "../../components/verify/verified-channels.json";
+import { checkInput, PLATFORM_LABELS } from "../../components/verify/verifyLogic";
+
+// Per-IP rate limit so the endpoint can't be used to enumerate phone numbers
+// or handles. Instances are reused under Fluid Compute, so an in-memory map
+// is effective enough for this purpose.
+const RATE_LIMIT = 20;
+const RATE_WINDOW_MS = 60_000;
+const hits = new Map();
+
+const isRateLimited = (ip) => {
+  const now = Date.now();
+  const recent = (hits.get(ip) || []).filter((t) => now - t < RATE_WINDOW_MS);
+  recent.push(now);
+  hits.set(ip, recent);
+  if (hits.size > 10_000) hits.clear();
+  return recent.length > RATE_LIMIT;
+};
+
+export default async function handler(req, res) {
+  if (req.method !== "POST") {
+    res.setHeader("Allow", "POST");
+    return res.status(405).json({ error: "Method not allowed" });
+  }
+
+  const ip = (req.headers["x-forwarded-for"] || "").split(",")[0].trim() || req.socket.remoteAddress || "unknown";
+  if (isRateLimited(ip)) {
+    return res.status(429).json({ error: "Too many attempts" });
+  }
+
+  const { input, platform } = req.body || {};
+  if (typeof input !== "string" || !input.trim() || input.length > 300 || !PLATFORM_LABELS[platform]) {
+    return res.status(400).json({ error: "Invalid request" });
+  }
+
+  // Without the pepper, hashed team entries can never match — that would return
+  // a dangerous false "not verified" for real team members, so fail loudly.
+  const pepper = process.env.VERIFY_PEPPER;
+  if (!pepper) {
+    return res.status(500).json({ error: "Verification is not configured" });
+  }
+
+  const result = await checkInput(input, platform, verifiedChannels, pepper);
+
+  // Only expose what the result card needs — never the full channel entry.
+  const match = result.match
+    ? {
+        type: result.match.type,
+        name: result.match.name,
+        role: result.match.role || null,
+        handle: result.match.handle || null,
+      }
+    : undefined;
+
+  return res.status(200).json({
+    status: result.status,
+    input: result.input,
+    domain: result.domain,
+    match,
+  });
+}

--- a/pages/verify.js
+++ b/pages/verify.js
@@ -1,0 +1,45 @@
+import Head from "next/head";
+
+import mainLayout from "../components/common/layout/mainLayout";
+import Verify from "../components/verify/verify";
+
+// getStaticProps keeps the data file server-side: only the public org channels
+// are serialized into the page — the client bundle never sees the JSON.
+export async function getStaticProps() {
+  const verifiedChannels = (await import("../components/verify/verified-channels.json")).default;
+  return {
+    props: {
+      publicChannels: verifiedChannels.channels.filter((channel) => channel.handle),
+    },
+  };
+}
+
+export default function VerifyPage({ publicChannels }) {
+  const title = "ETH Belgrade Channel Verification";
+  const description = "Protect yourself from fraud. Check whether an email address, phone number, Telegram handle, or X account officially belongs to the ETH Belgrade team.";
+
+  return (
+    <>
+      <Head>
+        <title>{title}</title>
+        <meta name="description" content={description} />
+
+        <meta property="og:title" content={title} />
+        <meta property="og:description" content={description} />
+        <meta property="og:type" content="website" />
+        <meta property="og:image" content="https://ethbelgrade.rs/eth-belgrade-og-2026.jpg" />
+
+        <meta name="twitter:card" content="summary_large_image" />
+        <meta name="twitter:title" content={title} />
+        <meta name="twitter:description" content={description} />
+        <meta name="twitter:site" content="@ethbelgrade" />
+        <meta name="twitter:image" content="https://ethbelgrade.rs/eth-belgrade-og-2026.jpg" />
+
+        <link rel="icon" href="/favicon.ico" />
+      </Head>
+      <Verify publicChannels={publicChannels} />
+    </>
+  );
+}
+
+VerifyPage.getLayout = mainLayout;

--- a/scripts/add-verified-channel.mjs
+++ b/scripts/add-verified-channel.mjs
@@ -1,0 +1,72 @@
+// Adds a team contact to components/verify/verified-channels.json as a salted
+// PBKDF2 hash, so the value is verifiable on /verify but never appears in the
+// repo or the public JS bundle.
+//
+// Usage:
+//   node scripts/add-verified-channel.mjs <type> <value> <name> [role]
+//   node scripts/add-verified-channel.mjs telegram @someuser "Jane Doe"
+//   node scripts/add-verified-channel.mjs phone "+381 60 000 0000" "Jane Doe"
+//
+// Types: telegram | x | linkedin | email | phone
+
+import { readFileSync, writeFileSync } from "fs";
+import { randomBytes } from "crypto";
+import { fileURLToPath } from "url";
+import { dirname, join } from "path";
+import { cleanValue, extractHandle, normalizePhoneDigits, deriveHash } from "../components/verify/verifyLogic.js";
+
+const DATA_PATH = join(dirname(fileURLToPath(import.meta.url)), "../components/verify/verified-channels.json");
+const SERBIA_COUNTRY_CODE = "381";
+
+// All input forms that should verify for a given value — e.g. a Serbian phone
+// number matches in both international (+381…) and local (06…) form.
+export const hashFormsFor = (type, value) => {
+  if (type === "phone") {
+    const digits = normalizePhoneDigits(value);
+    const forms = new Set([digits]);
+    if (digits.startsWith(SERBIA_COUNTRY_CODE)) forms.add(`0${digits.slice(SERBIA_COUNTRY_CODE.length)}`);
+    if (digits.startsWith("0")) forms.add(SERBIA_COUNTRY_CODE + digits.slice(1));
+    return [...forms];
+  }
+  if (type === "email") return [cleanValue(value).replace(/^@/, "")];
+  return [extractHandle(cleanValue(value))];
+};
+
+export const buildHashedEntry = async (type, value, name, role, kdf, pepper) => {
+  const hashes = await Promise.all(hashFormsFor(type, value).map((form) => deriveHash(type, form, kdf, pepper)));
+  return { type, hashes, name, role };
+};
+
+// The pepper never lives in the repo — read it from the environment or .env.local.
+export const loadPepper = () => {
+  if (process.env.VERIFY_PEPPER) return process.env.VERIFY_PEPPER;
+  try {
+    const envFile = readFileSync(join(dirname(fileURLToPath(import.meta.url)), "../.env.local"), "utf8");
+    const match = envFile.match(/^VERIFY_PEPPER=(.+)$/m);
+    if (match) return match[1].trim();
+  } catch {
+    // fall through
+  }
+  throw new Error("VERIFY_PEPPER not found — set it in .env.local or the environment.");
+};
+
+const isMain = process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1];
+
+if (isMain) {
+  const [type, value, name, role = "ETH Belgrade team"] = process.argv.slice(2);
+  if (!type || !value || !name) {
+    console.error("Usage: node scripts/add-verified-channel.mjs <type> <value> <name> [role]");
+    process.exit(1);
+  }
+
+  const pepper = loadPepper();
+  const data = JSON.parse(readFileSync(DATA_PATH, "utf8"));
+  if (!data.kdf) {
+    data.kdf = { salt: randomBytes(16).toString("hex"), iterations: 600000 };
+  }
+
+  const entry = await buildHashedEntry(type, value, name, role, data.kdf, pepper);
+  data.channels.push(entry);
+  writeFileSync(DATA_PATH, `${JSON.stringify(data, null, 2)}\n`);
+  console.log(`Added hashed ${type} entry for ${name} (${entry.hashes.length} accepted form(s)).`);
+}


### PR DESCRIPTION
## What

Anti-impersonation tool at `/verify` — anyone can check whether an email address, phone number, Telegram/X handle, or LinkedIn page officially belongs to the ETH Belgrade team (like CertiK's Worker Validation / OKX Channel Verification).

## How it works

- **Server-side verification**: the browser posts to `/api/verify`; the roster never ships to the client. Rate-limited per IP (20/min) to prevent enumeration.
- **No contact data in the repo**: personal contacts are stored only as PBKDF2 hashes salted with a secret pepper (`VERIFY_PEPPER` env var — already set in Vercel Production/Preview). Without the pepper the hashes cannot be brute-forced, so the public repo leaks nothing.
- **Scam-resistant matching**: exact per-platform matching, homoglyph/non-ASCII detection (Cyrillic lookalikes flagged before normalization), URL/`mailto:`/phone-format normalization, official email-domain fallback for unlisted `@ethbelgrade.rs` addresses.
- Only the 3 official org channels (X, Telegram group, LinkedIn) are shown publicly; team contacts are verifiable but not listed.
- New entries are added with `scripts/add-verified-channel.mjs` (requires `VERIFY_PEPPER` locally).

## Testing

- 77-case logic suite passes (real handles in both URL/handle/local-phone forms, lookalikes, homoglyphs, cross-platform collisions, domain tricks)
- Production build + live API exercised end to end, incl. 429 rate limiting
- Client bundle and prerendered HTML verified to contain no handles, phones, emails, hashes, or salt

🤖 Generated with [Claude Code](https://claude.com/claude-code)