### PR TITLE
Add verified Telegram channel: Natasa Bujosevic

### DIFF
--- a/components/verify/verified-channels.json
+++ b/components/verify/verified-channels.json
@@ -190,6 +190,14 @@
       ],
       "name": "General inquiries",
       "role": "Official general inbox"
+    },
+    {
+      "type": "telegram",
+      "hashes": [
+        "8be6d3eb668ea8dc042278996c8e771e3cafad0599299235a342b5bc0f9a6b5c"
+      ],
+      "name": "Natasa Bujosevic",
+      "role": "ETH Belgrade team"
     }
   ]
 }


### PR DESCRIPTION
Adds @strangechain (Natasa Bujosevic, ETH Belgrade team) to the /verify channel list as peppered PBKDF2 hashes via `scripts/add-verified-channel.mjs` — no plaintext contact data committed. Verified locally that the hash matches the handle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)