### PR TITLE
Add LiFi sponsor

### DIFF
--- a/components/landing/partners/partners.js
+++ b/components/landing/partners/partners.js
@@ -20,7 +20,7 @@ const partners = [
   // { href: "https://chain.link/", img: "/images/partners/chainlink-logo.svg", alt: "Chainlink logo" },
   // { href: "https://metamask.io/", img: "/images/partners/metamask-logo.svg", alt: "MetaMask logo" },
   // { href: "https://ledger.com/", img: "/images/partners/ledger-logo.svg", alt: "Ledger logo" },
-  // { href: "https://li.fi/", img: "/images/partners/lifi-logo.svg", alt: "LiFi logo" },
+  { href: "https://li.fi/", img: "/images/partners/lifi-logo.svg", alt: "LiFi logo" },
   // { href: "https://www.bnbchain.org/en", img: "/images/partners/bnb-chain-logo.svg", alt: "BNB Chain logo" },
   // { href: "https://linea.build/", img: "/images/partners/linea-logo.svg", alt: "Linea logo" },
   // { href: "https://neonevm.org/", img: "/images/partners/NeonEVM-logo.svg", alt: "Neon EVM logo" },


### PR DESCRIPTION
## Summary
- Enabled LiFi (https://li.fi/) in the sponsors section, reusing the existing logo
- Also carries a small "Update speakers" commit that was already on dev

🤖 Generated with [Claude Code](https://claude.com/claude-code)