### PR TITLE
Remove Tangem sponsor

### DIFF
--- a/components/landing/partners/partners.js
+++ b/components/landing/partners/partners.js
@@ -13,7 +13,7 @@ const partners = [
   { href: "https://lido.fi/", img: "/images/partners/lido-logo.svg", alt: "Lido logo" },
   { href: "https://curvy.box/", img: "/images/partners/curvy.svg", alt: "Curvy logo" },
   { href: "https://geode.build/", img: "/images/partners/geode-labs.svg", alt: "Geode Labs logo" },
-  { href: "https://tangem.com/", img: "/images/partners/tangem.svg", alt: "Tangem logo" },
+  // { href: "https://tangem.com/", img: "/images/partners/tangem.svg", alt: "Tangem logo" },
   // { href: "https://esp.ethereum.foundation/", img: "/images/partners/EF-ESP-logo.svg", alt: "Ethereum Foundation Ecosystem Support Program logo" },
   // { href: "https://polkadot.com/", img: "/images/partners/polkadot.svg", alt: "Polkadot logo" },
   // { href: "https://www.vidikovac.space/", img: "/images/partners/vidikovac.svg", alt: "Vidikovac logo" },


### PR DESCRIPTION
Removes Tangem from the sponsors/partners list on the landing page (commented out following the file's convention for inactive sponsors). Also carries the latest speaker updates from dev.

🤖 Generated with [Claude Code](https://claude.com/claude-code)