### PR TITLE
Normalize speaker photo sizing; fix dev font downloads

### DIFF
--- a/components/landing/speakers/speakers.module.scss
+++ b/components/landing/speakers/speakers.module.scss
@@ -122,28 +122,19 @@
   height: 180px;
   margin-bottom: 12px;
 
+  // Photos vary a lot in natural size, so fill the cutout box
+  // uniformly instead of rendering each at its own scale
   img {
-    width: auto;
-    height: auto;
-    max-width: 85%;
-    max-height: 100%;
+    width: 100%;
+    height: 100%;
     border-radius: 0;
     object-fit: contain;
+    object-position: bottom center;
     margin-bottom: 0;
     filter: grayscale(1);
     transition: filter 0.3s ease;
     mask-image: linear-gradient(to bottom, black 82%, transparent 100%);
     -webkit-mask-image: linear-gradient(to bottom, black 82%, transparent 100%);
-
-    // Phones: photos vary a lot in natural size, so fill the cutout box
-    // uniformly instead of rendering each at its own scale
-    @include breakpoint(big-mobile) {
-      width: 100%;
-      height: 100%;
-      max-width: 100%;
-      object-fit: contain;
-      object-position: bottom center;
-    }
   }
 
   @include breakpoint(big-mobile) {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "next dev",
+    "dev": "NODE_OPTIONS='--dns-result-order=ipv4first --no-network-family-autoselection' next dev",
     "build": "next build",
     "start": "next start",
     "lint": "next lint"


### PR DESCRIPTION
## Summary
- Speaker cutout photos now uniformly fill the cutout box on all screen sizes (previously each rendered at its natural resolution, so low-res photos looked tiny next to high-res ones)
- `npm run dev` now passes Node flags (`--dns-result-order=ipv4first --no-network-family-autoselection`) so `@next/font` can actually download Google Fonts in local dev instead of silently falling back to system fonts

🤖 Generated with [Claude Code](https://claude.com/claude-code)